### PR TITLE
Refactor effort/match field names, add long duration low joules test

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,6 +34,11 @@ develocity {
         publishing.onlyIf { false }
     }
 }
+
+val env: MutableMap<String, String> = System.getenv()
+val gprUser = if(env.containsKey("GPR_USER")) env["GPR_USER"] else getLocalProperty("gpr.user")
+val gprKey = if(env.containsKey("GPR_KEY")) env["GPR_KEY"] else getLocalProperty("gpr.key")
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
@@ -43,8 +48,8 @@ dependencyResolutionManagement {
         maven {
             url = uri("https://maven.pkg.github.com/hammerheadnav/karoo-ext")
             credentials {
-                username = getLocalProperty("gpr.user")
-                password = getLocalProperty("gpr.key")
+                username = gprUser
+                password = gprKey
             }
         }
     }


### PR DESCRIPTION
Renamed "Match Joules" and "Match Duration" data types in strings.xml to "Effort Joules" and "Effort Duration" respectively for better clarity.

Added a new test case to `WPrimeCalculatorTest.kt` to ensure that long-duration efforts with low joules depleted do not register as a "match." This test verifies the correct behavior of the effort evaluation logic when recovery occurs after an effort that meets duration but not joule depletion criteria.

Removed the `values-night/strings.xml` file as it was a duplicate of the default `values/strings.xml` and not providing any distinct night mode resources.